### PR TITLE
Fixed incorrect syntax in header code

### DIFF
--- a/docs/_data/general.yml
+++ b/docs/_data/general.yml
@@ -10,11 +10,11 @@ header:
       import gym
       env = gym.make("LunarLander-v2")
       observation = env.reset()
-      for _ in range(1000)
+      for _ in range(1000):
         env.render()
         action = policy(observation)
         observation, reward, done, info = env.step(action)
 
-        if done
+        if done:
           observation = env.reset()
       env.close()


### PR DESCRIPTION
The code snippet in `general.yml` was missing two colons. 
I have added them and I am fairly (not 100% because I can't test it) certain that this is valid YAML that will produce the correct result.