### PR TITLE
Fixed Flavor Table in Atari index.md

### DIFF
--- a/docs/pages/environments/atari/index.md
+++ b/docs/pages/environments/atari/index.md
@@ -66,7 +66,7 @@ the number of available modes and difficulty levels for different Atari games:
 
 |Title|# Modes|# Difficulties|
 | ----------- | ----------- | -----------|
-|AirRaid|9|1|       # Not mentioned in paper
+|AirRaid|9|1|
 |Alien|4|4|
 |Amidar|1|2|
 |Assault|1|1|


### PR DESCRIPTION
I had added a comment to the first row of a table in index.md. This comment caused a fourth column to be rendered on the HTML page. The comment is of little relevance (I wager it applies to many other games listed in the table) and therefore I just removed it.