### PR TITLE
Correcting Information on Game Modes

### DIFF
--- a/docs/pages/environments/atari/air_raid.md
+++ b/docs/pages/environments/atari/air_raid.md
@@ -58,9 +58,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|AirRaid|9|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|          AirRaid | `[1, ..., 8]`                                                                                                                                                                       |              `[0]` | `1`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/alien.md
+++ b/docs/pages/environments/atari/alien.md
@@ -55,9 +55,10 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|Alien|4|4|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|            Alien | `[0, ..., 3]`                                                                                                                                                                       |      `[0, ..., 3]` | `0`          |
+
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/amidar.md
+++ b/docs/pages/environments/atari/amidar.md
@@ -68,9 +68,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|Amidar|1|2|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|           Amidar | `[0]`                                                                                                                                                                               |           `[0, 3]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/assault.md
+++ b/docs/pages/environments/atari/assault.md
@@ -56,9 +56,10 @@ env = gym.make("ALE/Assault-v5")
 
 The various ways to configure the environment are described in detail in the article on Atari environments.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|Assault|1|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|          Assault | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/asterix.md
+++ b/docs/pages/environments/atari/asterix.md
@@ -65,9 +65,10 @@ env = gym.make("ALE/Asterix-v5")
 
 The various ways to configure the environment are described in detail in the article on Atari environments.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|Asterix|1|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|          Asterix | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/asteroids.md
+++ b/docs/pages/environments/atari/asteroids.md
@@ -74,9 +74,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title     | # Modes |# Difficulties|
-|-----------|---------| -----------|
-| Asteroids | 32      |1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|        Asteroids | `[0, ..., 31, 128]`                                                                                                                                                                 |           `[0, 3]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/atlantis.md
+++ b/docs/pages/environments/atari/atlantis.md
@@ -64,9 +64,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title    | # Modes | # Difficulties |
-|----------|---------|----------------|
-| Atlantis | 4       | 1              |
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|         Atlantis | `[0, ..., 3]`                                                                                                                                                                       |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/bank_heist.md
+++ b/docs/pages/environments/atari/bank_heist.md
@@ -56,9 +56,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title     | # Modes | # Difficulties |
-|-----------|---------|----------------|
-| BankHeist | 1       | 4              |
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|        BankHeist | `[0, 4, 8, 12, 16, 20, 24, 28]`                                                                                                                                                     |      `[0, ..., 3]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/battle_zone.md
+++ b/docs/pages/environments/atari/battle_zone.md
@@ -55,9 +55,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title      | # Modes |# Difficulties|
-|------------|---------| -----------|
-| BattleZone | 4       |1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|       BattleZone | `[1, 2, 3]`                                                                                                                                                                         |              `[0]` | `1`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/beam_rider.md
+++ b/docs/pages/environments/atari/beam_rider.md
@@ -68,9 +68,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title     | # Modes | # Difficulties |
-|-----------|---------|----------------|
-| BeamRider | 1       | 2              |
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|        BeamRider | `[0]`                                                                                                                                                                               |           `[0, 1]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/berzerk.md
+++ b/docs/pages/environments/atari/berzerk.md
@@ -54,9 +54,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title   | # Modes |# Difficulties|
-|---------|---------| -----------|
-| Berzerk | 10      |1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|          Berzerk | `[1, ..., 9, 16, 17, 18]`                                                                                                                                           |              `[0]` | `1`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/bowling.md
+++ b/docs/pages/environments/atari/bowling.md
@@ -67,9 +67,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title   | # Modes | # Difficulties |
-|---------|---------|----------------|
-| Bowling | 1       | 2              |
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|          Bowling | `[0, 2, 4]`                                                                                                                                                                         |           `[0, 1]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/boxing.md
+++ b/docs/pages/environments/atari/boxing.md
@@ -52,9 +52,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title  |# Modes| # Difficulties |
-|--------| ----------- |----------------|
-| Boxing |1| 4              |
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|           Boxing | `[0]`                                                                                                                                                                               |      `[0, ..., 3]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/breakout.md
+++ b/docs/pages/environments/atari/breakout.md
@@ -62,9 +62,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title    |# Modes|# Difficulties|
-|----------| ----------- | -----------|
-| Breakout |1|2|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|         Breakout | `[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44]`                                                                                                                                     |           `[0, 1]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/carnival.md
+++ b/docs/pages/environments/atari/carnival.md
@@ -66,9 +66,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title    |# Modes| # Difficulties |
-|----------| ----------- |----------------|
-| Carnival |1| 1              |
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|         Carnival | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/centipede.md
+++ b/docs/pages/environments/atari/centipede.md
@@ -57,9 +57,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title     | # Modes |# Difficulties|
-|-----------|---------| -----------|
-| Centipede | 1       |1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|        Centipede | `[22, 86]`                                                                                                                                                                          |              `[0]` | `22`         |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/chopper_command.md
+++ b/docs/pages/environments/atari/chopper_command.md
@@ -54,9 +54,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title          | # Modes | # Difficulties |
-|----------------|---------|----------------|
-| ChopperCommand | 1       | 2              |
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|   ChopperCommand | `[0, 2]`                                                                                                                                                                            |           `[0, 1]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/crazy_climber.md
+++ b/docs/pages/environments/atari/crazy_climber.md
@@ -69,9 +69,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|Crazy Climber|4|2|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|     CrazyClimber | `[0, ..., 3]`                                                                                                                                                                       |           `[0, 1]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/demon_attack.md
+++ b/docs/pages/environments/atari/demon_attack.md
@@ -70,9 +70,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|DemonAttack|4|2|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|      DemonAttack | `[1, 3, 5, 7]`                                                                                                                                                                      |           `[0, 1]` | `1`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/double_dunk.md
+++ b/docs/pages/environments/atari/double_dunk.md
@@ -68,9 +68,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|DoubleDunk|16|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|       DoubleDunk | `[0, ..., 15]`                                                                                                                                                                      |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/elevator_action.md
+++ b/docs/pages/environments/atari/elevator_action.md
@@ -71,9 +71,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|ElevatorAction|1|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|   ElevatorAction | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/enduro.md
+++ b/docs/pages/environments/atari/enduro.md
@@ -66,9 +66,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|Enduro|1|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|           Enduro | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/ice_hockey.md
+++ b/docs/pages/environments/atari/ice_hockey.md
@@ -55,9 +55,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|IceHockey|2|4|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|        IceHockey | `[0, 2]`                                                                                                                                                                            |      `[0, ..., 3]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/index.md
+++ b/docs/pages/environments/atari/index.md
@@ -61,8 +61,8 @@ random between `frameskip[0]` (inclusive) and `frameskip[1]` (exclusive) in each
 ### Flavors
 Some games allow the user to set a difficulty level and a game mode. Different modes/difficulties may have different
 game dynamics and (if a reduced action space is used) different action spaces. We follow the convention of [[2]](#2) and
-refer to the combination of difficulty level and game mode as a flavor of a game. The following table from [[2]](#2) shows
-the number of available modes and difficulty levels for different Atari games:
+refer to the combination of difficulty level and game mode as a flavor of a game. The following table shows
+the available modes and difficulty levels for different Atari games:
 
 |      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
 |------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
@@ -170,8 +170,6 @@ the number of available modes and difficulty levels for different Atari games:
 |       WordZapper | `[0, ..., 23]`                                                                                                                                                                      |      `[0, ..., 3]` | `0`          |
 |      YarsRevenge | `[0, 32, 64, 96]`                                                                                                                                                                   |           `[0, 1]` | `0`          |
 |           Zaxxon | `[0, 8, 16, 24]`                                                                                                                                                                    |              `[0]` | `0`          |
-
-
 
 
 

--- a/docs/pages/environments/atari/index.md
+++ b/docs/pages/environments/atari/index.md
@@ -64,28 +64,115 @@ game dynamics and (if a reduced action space is used) different action spaces. W
 refer to the combination of difficulty level and game mode as a flavor of a game. The following table from [[2]](#2) shows
 the number of available modes and difficulty levels for different Atari games:
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|AirRaid|9|1|
-|Alien|4|4|
-|Amidar|1|2|
-|Assault|1|1|
-|Asterix|1|1|
-|Asteroids|32|1|
-|Atlantis|4|1|
-| BankHeist | 1       | 4              |
-| BattleZone | 4       |1|
-| BeamRider | 1       | 2              |
-| Berzerk | 10      |1|
-| Bowling | 1       | 2              |
-| Boxing |1| 4              |
-| Breakout |1|2|
-| Carnival |1| 1              |
-|Crazy Climber|4|2|
-|Demon Attack|4|2|
-|Double Dunk|16|1|
-|Elevator Action|1|1|
-|Enduro|1|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|        Adventure | `[0, 1, 2]`                                                                                                                                                                         |      `[0, ..., 3]` | `0`          |
+|          AirRaid | `[1, ..., 8]`                                                                                                                                                                       |              `[0]` | `1`          |
+|            Alien | `[0, ..., 3]`                                                                                                                                                                       |      `[0, ..., 3]` | `0`          |
+|           Amidar | `[0]`                                                                                                                                                                               |           `[0, 3]` | `0`          |
+|          Assault | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|          Asterix | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|        Asteroids | `[0, ..., 31, 128]`                                                                                                                                                                 |           `[0, 3]` | `0`          |
+|         Atlantis | `[0, ..., 3]`                                                                                                                                                                       |              `[0]` | `0`          |
+|        Atlantis2 | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|       Backgammon | `[0]`                                                                                                                                                                               |              `[3]` | `0`          |
+|        BankHeist | `[0, 4, 8, 12, 16, 20, 24, 28]`                                                                                                                                                     |      `[0, ..., 3]` | `0`          |
+|        BasicMath | `[5, ..., 8]`                                                                                                                                                                       |        `[0, 2, 3]` | `5`          |
+|       BattleZone | `[1, 2, 3]`                                                                                                                                                                         |              `[0]` | `1`          |
+|        BeamRider | `[0]`                                                                                                                                                                               |           `[0, 1]` | `0`          |
+|          Berzerk | `[1, ..., 9, 16, 17, 18]`                                                                                                                                           |              `[0]` | `1`          |
+|        Blackjack | `[0]`                                                                                                                                                                               |      `[0, ..., 3]` | `0`          |
+|          Bowling | `[0, 2, 4]`                                                                                                                                                                         |           `[0, 1]` | `0`          |
+|           Boxing | `[0]`                                                                                                                                                                               |      `[0, ..., 3]` | `0`          |
+|         Breakout | `[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44]`                                                                                                                                     |           `[0, 1]` | `0`          |
+|         Carnival | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|           Casino | `[0, 2, 3]`                                                                                                                                                                         |      `[0, ..., 3]` | `0`          |
+|        Centipede | `[22, 86]`                                                                                                                                                                          |              `[0]` | `22`         |
+|   ChopperCommand | `[0, 2]`                                                                                                                                                                            |           `[0, 1]` | `0`          |
+|     CrazyClimber | `[0, ..., 3]`                                                                                                                                                                       |           `[0, 1]` | `0`          |
+|         Crossbow | `[0, 2, 4, 6]`                                                                                                                                                                      |           `[0, 1]` | `0`          |
+|     Darkchambers | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|         Defender | `[1, ..., 9, 16]`                                                                                                                                                                   |           `[0, 1]` | `1`          |
+|      DemonAttack | `[1, 3, 5, 7]`                                                                                                                                                                      |           `[0, 1]` | `1`          |
+|       DonkeyKong | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|       DoubleDunk | `[0, ..., 15]`                                                                                                                                                                      |              `[0]` | `0`          |
+|       Earthworld | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|   ElevatorAction | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|           Enduro | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|         Entombed | `[0]`                                                                                                                                                                               |           `[0, 2]` | `0`          |
+|               Et | `[0, 1, 2]`                                                                                                                                                                         |      `[0, ..., 3]` | `0`          |
+|     FishingDerby | `[0]`                                                                                                                                                                               |      `[0, ..., 3]` | `0`          |
+|      FlagCapture | `[8, 9, 10]`                                                                                                                                                                        |              `[0]` | `8`          |
+|          Freeway | `[0, ..., 7]`                                                                                                                                                                       |           `[0, 1]` | `0`          |
+|          Frogger | `[0, 1, 2]`                                                                                                                                                                         |           `[0, 1]` | `0`          |
+|        Frostbite | `[0, 2]`                                                                                                                                                                            |              `[0]` | `0`          |
+|         Galaxian | `[1, ..., 9]`                                                                                                                                                                       |           `[0, 1]` | `1`          |
+|           Gopher | `[0, 2]`                                                                                                                                                                            |           `[0, 1]` | `0`          |
+|         Gravitar | `[0, ..., 4]`                                                                                                                                                                       |              `[0]` | `0`          |
+|          Hangman | `[0, ..., 3]`                                                                                                                                                                       |           `[0, 1]` | `0`          |
+|     HauntedHouse | `[0, ..., 8]`                                                                                                                                                                       |           `[0, 1]` | `0`          |
+|             Hero | `[0, ..., 4]`                                                                                                                                                                       |              `[0]` | `0`          |
+|  HumanCannonball | `[0, ..., 7]`                                                                                                                                                                       |           `[0, 1]` | `0`          |
+|        IceHockey | `[0, 2]`                                                                                                                                                                            |      `[0, ..., 3]` | `0`          |
+|        Jamesbond | `[0, 1]`                                                                                                                                                                            |              `[0]` | `0`          |
+|    JourneyEscape | `[0]`                                                                                                                                                                               |           `[0, 1]` | `0`          |
+|           Kaboom | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|         Kangaroo | `[0, 1]`                                                                                                                                                                            |              `[0]` | `0`          |
+|   KeystoneKapers | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|         KingKong | `[0, ..., 3]`                                                                                                                                                                       |              `[0]` | `0`          |
+|             Klax | `[0, 1, 2]`                                                                                                                                                                         |              `[0]` | `0`          |
+|          Koolaid | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|            Krull | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|     KungFuMaster | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|       LaserGates | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|      LostLuggage | `[0, 1]`                                                                                                                                                                            |           `[0, 1]` | `0`          |
+|        MarioBros | `[0, 2, 4, 6]`                                                                                                                                                                      |              `[0]` | `0`          |
+|    MiniatureGolf | `[0]`                                                                                                                                                                               |           `[0, 1]` | `0`          |
+| MontezumaRevenge | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|             MrDo | `[0, ..., 3]`                                                                                                                                                                       |              `[0]` | `0`          |
+|         MsPacman | `[0, ..., 3]`                                                                                                                                                                       |              `[0]` | `0`          |
+|     NameThisGame | `[8, 24, 40]`                                                                                                                                                                       |           `[0, 1]` | `8`          |
+|          Othello | `[0, 1, 2]`                                                                                                                                                                         |           `[0, 2]` | `0`          |
+|           Pacman | `[0, ..., 7]`                                                                                                                                                                       |           `[0, 1]` | `0`          |
+|          Phoenix | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|          Pitfall | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|         Pitfall2 | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|             Pong | `[0, 1]`                                                                                                                                                                            |      `[0, ..., 3]` | `0`          |
+|           Pooyan | `[10, 30, 50, 70]`                                                                                                                                                                  |              `[0]` | `10`         |
+|       PrivateEye | `[0, ..., 4]`                                                                                                                                                                       |      `[0, ..., 3]` | `0`          |
+|            Qbert | `[0]`                                                                                                                                                                               |           `[0, 1]` | `0`          |
+|        Riverraid | `[0]`                                                                                                                                                                               |           `[0, 1]` | `0`          |
+|       RoadRunner | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|         Robotank | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|         Seaquest | `[0]`                                                                                                                                                                               |           `[0, 1]` | `0`          |
+|      SirLancelot | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|           Skiing | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|          Solaris | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|    SpaceInvaders | `[0, ..., 15]`                                                                                                                                                                      |           `[0, 1]` | `0`          |
+|         SpaceWar | `[6, ..., 17]`                                                                                                                                                                      |              `[0]` | `6`          |
+|       StarGunner | `[0, ..., 3]`                                                                                                                                                                       |              `[0]` | `0`          |
+|         Superman | `[0]`                                                                                                                                                                               |      `[0, ..., 3]` | `0`          |
+|         Surround | `[0, 2]`                                                                                                                                                                            |      `[0, ..., 3]` | `0`          |
+|           Tennis | `[0, 2]`                                                                                                                                                                            |      `[0, ..., 3]` | `0`          |
+|           Tetris | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
+|      TicTacToe3D | `[0, ..., 8]`                                                                                                                                                                       |           `[0, 2]` | `0`          |
+|        TimePilot | `[0]`                                                                                                                                                                               |        `[0, 1, 2]` | `0`          |
+|         Trondead | `[0]`                                                                                                                                                                               |           `[0, 1]` | `0`          |
+|          Turmoil | `[0, ..., 8]`                                                                                                                                                                       |              `[0]` | `0`          |
+|        Tutankham | `[0, 4, 8, 12]`                                                                                                                                                                     |              `[0]` | `0`          |
+|          UpNDown | `[0]`                                                                                                                                                                               |      `[0, ..., 3]` | `0`          |
+|          Venture | `[0]`                                                                                                                                                                               |      `[0, ..., 3]` | `0`          |
+|    VideoCheckers | `[1, ..., 9, 11, 12, ..., 19]`                                                                                                                   |              `[0]` | `1`          |
+|     VideoPinball | `[0, 2]`                                                                                                                                                                            |           `[0, 1]` | `0`          |
+|       Videochess | `[0, ..., 4]`                                                                                                                                                                       |              `[0]` | `0`          |
+|        Videocube | `[0, 1, 2, 100, 101, 102, 200, 201, 202, 300, 301, ..., 5000, 5001, 5002]`                                                                                                           |           `[0, 1]` | `0`          |
+|      WizardOfWor | `[0]`                                                                                                                                                                               |           `[0, 1]` | `0`          |
+|       WordZapper | `[0, ..., 23]`                                                                                                                                                                      |      `[0, ..., 3]` | `0`          |
+|      YarsRevenge | `[0, 32, 64, 96]`                                                                                                                                                                   |           `[0, 1]` | `0`          |
+|           Zaxxon | `[0, 8, 16, 24]`                                                                                                                                                                    |              `[0]` | `0`          |
+
+
+
 
 
 

--- a/docs/pages/environments/atari/index.md
+++ b/docs/pages/environments/atari/index.md
@@ -181,10 +181,10 @@ When initializing Atari environments via `gym.make`, you may pass some additiona
 Atari environment. However, legal values for `mode` and `difficulty` depend on the environment.
 
 
-`mode`: `int`. Game mode, see [[2]](#2). Legal values are in {0, ..., **# Modes** - 1}.
+`mode`: `int`. Game mode, see [[2]](#2). Legal values depend on the environment and are listed in the table above.
 
-`difficulty`: `int`. Difficulty of the game, see [[2]](#2).. Legal values are in {0, ..., **# Difficulties** - 1}.
-Together with `mode`, this determines the "flavor" of the game.
+`difficulty`: `int`. Difficulty of the game, see [[2]](#2). Legal values depend on the environment and are listed in 
+the table above. Together with `mode`, this determines the "flavor" of the game.
 
 `obs_type`: `str`. This argument determines what observations are returned by the environment:
 - "ram": The 128 Bytes of RAM are returned

--- a/docs/pages/environments/atari/jamesbond.md
+++ b/docs/pages/environments/atari/jamesbond.md
@@ -56,9 +56,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|Jamesbond|2|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|        Jamesbond | `[0, 1]`                                                                                                                                                                            |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/journey_escape.md
+++ b/docs/pages/environments/atari/journey_escape.md
@@ -77,9 +77,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|JourneyEscape|1|2|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|    JourneyEscape | `[0]`                                                                                                                                                                               |           `[0, 1]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/kangaroo.md
+++ b/docs/pages/environments/atari/kangaroo.md
@@ -54,9 +54,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|Kangaroo|2|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|         Kangaroo | `[0, 1]`                                                                                                                                                                            |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/krull.md
+++ b/docs/pages/environments/atari/krull.md
@@ -54,9 +54,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|Krull|1|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|            Krull | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/kung_fu_master.md
+++ b/docs/pages/environments/atari/kung_fu_master.md
@@ -58,9 +58,9 @@ env = gym.make("ALE/KungFuMaster-v5")
 
 The various ways to configure the environment are described in detail in the article on Atari environments.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|KungFuMaster|1|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|     KungFuMaster | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/montezuma_revenge.md
+++ b/docs/pages/environments/atari/montezuma_revenge.md
@@ -43,9 +43,9 @@ env = gym.make("ALE/MontezumaRevenge-v5")
 
 The various ways to configure the environment are described in detail in the article on Atari environments.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|MontezumaRevenge|1|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+| MontezumaRevenge | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/ms_pacman.md
+++ b/docs/pages/environments/atari/ms_pacman.md
@@ -54,9 +54,9 @@ env = gym.make("ALE/MsPacman-v5")
 
 The various ways to configure the environment are described in detail in the article on Atari environments.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|MsPacman|1|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|         MsPacman | `[0, ..., 3]`                                                                                                                                                                       |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/name_this_game.md
+++ b/docs/pages/environments/atari/name_this_game.md
@@ -51,9 +51,9 @@ env = gym.make("ALE/NameThisGame-v5")
 
 The various ways to configure the environment are described in detail in the article on Atari environments.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|NameThisGame|1|2|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|     NameThisGame | `[8, 24, 40]`                                                                                                                                                                       |           `[0, 1]` | `8`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/phoenix.md
+++ b/docs/pages/environments/atari/phoenix.md
@@ -52,9 +52,9 @@ env = gym.make("ALE/Phoenix-v5")
 
 The various ways to configure the environment are described in detail in the article on Atari environments.
 
-|Title|# Modes|# Difficulties|
-| ----------- | ----------- | -----------|
-|Phoenix|1|1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|          Phoenix | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "Noframeskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/pitfall.md
+++ b/docs/pages/environments/atari/pitfall.md
@@ -49,9 +49,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title   | # Modes |# Difficulties|
-|---------|---------| -----------|
-| Pitfall | 1       |1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|          Pitfall | `[0]`                                                                                                                                                                               |              `[0]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/pong.md
+++ b/docs/pages/environments/atari/pong.md
@@ -61,9 +61,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title   | # Modes |# Difficulties|
-|---------|---------| -----------|
-| Pong | 2       |4|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|             Pong | `[0, 1]`                                                                                                                                                                            |      `[0, ..., 3]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/pooyan.md
+++ b/docs/pages/environments/atari/pooyan.md
@@ -62,9 +62,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title   | # Modes |# Difficulties|
-|---------|---------| -----------|
-| Pooyan | 4       |1|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|           Pooyan | `[10, 30, 50, 70]`                                                                                                                                                                  |              `[0]` | `10`         |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/private_eye.md
+++ b/docs/pages/environments/atari/private_eye.md
@@ -49,9 +49,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title   | # Modes |# Difficulties|
-|---------|---------| -----------|
-| PrivateEye | 5       |4|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|       PrivateEye | `[0, ..., 4]`                                                                                                                                                                       |      `[0, ..., 3]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/pages/environments/atari/qbert.md
+++ b/docs/pages/environments/atari/qbert.md
@@ -60,9 +60,9 @@ The various ways to configure the environment are described in detail in the art
 It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
 A flavor is a combination of a game mode and a difficulty setting.
 
-| Title   | # Modes |# Difficulties|
-|---------|---------| -----------|
-| Qbert | 1       |2|
+|      Environment | Valid Modes                                                                                                                                                                         | Valid Difficulties | Default Mode |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|--------------|
+|            Qbert | `[0]`                                                                                                                                                                               |           `[0, 1]` | `0`          |
 
 You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
 are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 

--- a/docs/scripts/gen_atari_table.py
+++ b/docs/scripts/gen_atari_table.py
@@ -1,0 +1,40 @@
+import gym
+from rich.table import Table
+from rich.console import Console
+from rich import box
+from tqdm import tqdm
+
+
+def shortened_repr(lst):
+    assert all((isinstance(item, int) for item in lst))
+    assert len(set(lst)) == len(lst)
+    lst = sorted(lst)
+
+    if lst[-1] - lst[0] == len(lst) - 1 and len(lst) > 3:
+        return f"`[{lst[0]}, ..., {lst[-1]}]`"
+    elif len(lst) > 3 and lst[-2] - lst[0] == len(lst) - 2:
+        return f"`[{lst[0]}, ..., {lst[-2]}, {lst[-1]}]`"
+    return f"`{str(lst)}`"
+
+
+current_atari_envs = sorted(
+    [env_spec.id for env_spec in gym.envs.registry.all() if env_spec.id.startswith("ALE") and "ram" not in env_spec.id])
+
+table = Table(title="Atari Flavors", box=box.ASCII)
+
+table.add_column("Environment", no_wrap=True)
+table.add_column("Valid Modes")
+table.add_column("Valid Difficulties")
+table.add_column("Default Mode")
+
+for env_name in tqdm(current_atari_envs):
+    env = gym.make(env_name)
+    valid_modes = env.unwrapped.ale.getAvailableModes()
+    valid_difficulties = env.unwrapped.ale.getAvailableDifficulties()
+    difficulty = env.unwrapped.ale.cloneState().getDifficulty()
+    assert (difficulty == 0), difficulty
+    table.add_row(env_name.split("/")[1].split("-")[0], shortened_repr(valid_modes), shortened_repr(valid_difficulties),
+                  f"`{env.unwrapped.ale.cloneState().getCurrentMode()}`")
+
+console = Console()
+console.print(table)


### PR DESCRIPTION
I had incorrectly assumed that the set of valid Atari game modes is of the form {0, ..., n}. I was corrected here: https://github.com/Farama-Foundation/gym-docs/pull/39#issuecomment-1030656646 . Thus, I am raising this pull request to correct the mistake

I implemented a script to automatically generate a table of valid game modes, valid difficulties and default game modes (default difficulty seems to be 0 everywhere). The resulting table is gigantic, so we might not want to include it directly in index.md, unless there is some way to collapse it in the HTML page. Nevertheless, I have added it for now for reference. What's your opinion on where this information should go?

I still need to go through the individual environment pages and update the information there.