### PR TITLE
Add .md for solaris through time_pilot

### DIFF
--- a/docs/pages/environments/atari/solaris.md
+++ b/docs/pages/environments/atari/solaris.md
@@ -1,0 +1,66 @@
+---
+layout: env
+title: Solaris
+grid:
+   - Action Space: Discrete(18)
+   - Observation Shape: (210, 160, 3)
+   - Observation High: 255
+   - Observation Low: 0
+   - Import: <code>gym.make("ALE/Solaris-v5")</code>
+---
+
+### Description
+You control a spaceship. Blast enemies before they can blast you. You can warp to different sectors. You have to defend Federation planets, and destroy Zylon forces. Keep track of your fuel, if you run out you lose a life. Warp to a Federation planet to refuel. The game ends if all your ships are destroyed or if you reach the Solaris planet. Detailed documentation can be found on [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=450)
+
+### Actions
+By default, all actions that can be performed on an Atari 2600 are available in this environment.
+Even if you use v0 or v4 or specify `full_action_space=False` during initialization, all actions will be available in the default flavor.
+
+### Observations
+By default, the environment returns the RGB image that is displayed to human players as an observation. However, it is possible to observe
+- The 128 Bytes of RAM of the console
+- A grayscale image
+
+instead. The respective observation spaces are
+- `Box([0 ... 0], [255 ... 255], (128,), uint8)`
+- `Box([[0 ... 0]
+ ...
+ [0  ... 0]], [[255 ... 255]
+ ...
+ [255  ... 255]], (250, 160), uint8)
+`
+
+respectively. The general article on Atari environments outlines different ways to instantiate corresponding environments
+via `gym.make`.
+
+### Rewards
+
+You gain points for destroying enemies, rescuing cadets, making it through a corridor, destroying enemy planets etc. For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=450).
+
+### Arguments
+
+```
+env = gym.make("ALE/Solaris-v5")
+```
+
+The various ways to configure the environment are described in detail in the article on Atari environments.
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
+A flavor is a combination of a game mode and a difficulty setting.
+
+| Title   | # Modes |# Difficulties|
+|---------|---------| -----------|
+| Solaris | 1       |1|
+
+You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
+are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 
+the general article on Atari environments.
+The versions v0 and v4 are not contained in the "ALE" namespace. I.e. they are instantiated via `gym.make("Solaris-v0")`.
+
+### Version History
+A thorough discussion of the intricate differences between the versions and configurations can be found in the
+general article on Atari environments. 
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The entire action space is used by default. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release (1.0.0)
+

--- a/docs/pages/environments/atari/space_invaders.md
+++ b/docs/pages/environments/atari/space_invaders.md
@@ -1,0 +1,79 @@
+---
+layout: env
+title: SpaceInvaders
+grid:
+   - Action Space: Discrete(18)
+   - Observation Shape: (210, 160, 3)
+   - Observation High: 255
+   - Observation Low: 0
+   - Import: <code>gym.make("ALE/SpaceInvaders-v5")</code>
+---
+
+### Description
+
+Your objective is to destroy the space invaders by shooting your laser cannon at them before they reach the Earth. The game ends when all your lives are lost after taking enemy fire, or when they reach the earth. Detailed documentation can be found on [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=460)
+
+### Actions
+By default, all actions that can be performed on an Atari 2600 are available in this environment.
+However, if you use v0 or v4 or specify `full_action_space=False` during initialization, only a reduced
+number of actions (those that are meaningful in this game) are available. The reduced action space may depend on the flavor of the environment (the combination of `mode` and `difficulty`). The reduced action space for the default 
+flavor looks like this:
+
+| Num | Action                 |
+|-----|------------------------|
+| 0   | NOOP |
+| 1   | FIRE |
+| 2   | RIGHT |
+| 3   | LEFT |
+| 4   | RIGHTFIRE |
+| 5   | LEFTFIRE |
+
+
+### Observations
+By default, the environment returns the RGB image that is displayed to human players as an observation. However, it is possible to observe
+- The 128 Bytes of RAM of the console
+- A grayscale image
+
+instead. The respective observation spaces are
+- `Box([0 ... 0], [255 ... 255], (128,), uint8)`
+- `Box([[0 ... 0]
+ ...
+ [0  ... 0]], [[255 ... 255]
+ ...
+ [255  ... 255]], (250, 160), uint8)
+`
+
+respectively. The general article on Atari environments outlines different ways to instantiate corresponding environments
+via `gym.make`.
+
+### Rewards
+
+You gain points for destroying space invaders. The invaders in the back rows are worth more points. For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=460).
+
+### Arguments
+
+```
+env = gym.make("ALE/SpaceInvaders-v5")
+```
+
+The various ways to configure the environment are described in detail in the article on Atari environments.
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
+A flavor is a combination of a game mode and a difficulty setting.
+
+| Title   | # Modes |# Difficulties|
+|---------|---------| -----------|
+| SpaceInvaders | 16       |2|
+
+You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
+are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 
+the general article on Atari environments.
+The versions v0 and v4 are not contained in the "ALE" namespace. I.e. they are instantiated via `gym.make("SpaceInvaders-v0")`.
+
+### Version History
+A thorough discussion of the intricate differences between the versions and configurations can be found in the
+general article on Atari environments. 
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The entire action space is used by default. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release (1.0.0)
+

--- a/docs/pages/environments/atari/star_gunner.md
+++ b/docs/pages/environments/atari/star_gunner.md
@@ -1,0 +1,80 @@
+---
+layout: env
+title: StarGunner
+grid:
+   - Action Space: Discrete(18)
+   - Observation Shape: (210, 160, 3)
+   - Observation High: 255
+   - Observation Low: 0
+   - Import: <code>gym.make("ALE/StarGunner-v5")</code>
+---
+
+### Description
+
+Stop the alien invasion by shooting down alien saucers and creatures while avoiding bombs. More details can be found on [the Atari Mania page](http://www.atarimania.com/game-atari-2600-vcs-stargunner_16921.html)
+
+### Actions
+By default, all actions that can be performed on an Atari 2600 are available in this environment.
+However, if you use v0 or v4 or specify `full_action_space=False` during initialization, only a reduced
+number of actions (those that are meaningful in this game) are available. The reduced action space may depend on the flavor of the environment (the combination of `mode` and `difficulty`). The reduced action space for the default 
+flavor looks like this:
+
+| Num | Action                 |
+|-----|------------------------|
+| 0   | NOOP |
+| 1   | FIRE |
+| 2   | UP |
+| 3   | RIGHT |
+| 4   | LEFT |
+| 5   | DOWN |
+
+
+### Observations
+By default, the environment returns the RGB image that is displayed to human players as an observation. However, it is possible to observe
+- The 128 Bytes of RAM of the console
+- A grayscale image
+
+instead. The respective observation spaces are
+- `Box([0 ... 0], [255 ... 255], (128,), uint8)`
+- `Box([[0 ... 0]
+ ...
+ [0  ... 0]], [[255 ... 255]
+ ...
+ [255  ... 255]], (250, 160), uint8)
+`
+
+respectively. The general article on Atari environments outlines different ways to instantiate corresponding environments
+via `gym.make`.
+
+### Rewards
+
+You score points for destroying enemies. You get bonus points for clearing a wave and a level. For a more detailed documentation, see [the Atari Mania page](http://www.atarimania.com/game-atari-2600-vcs-stargunner_16921.html).
+
+
+### Arguments
+
+```
+env = gym.make("ALE/StarGunner-v5")
+```
+
+The various ways to configure the environment are described in detail in the article on Atari environments.
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
+A flavor is a combination of a game mode and a difficulty setting.
+
+| Title   | # Modes |# Difficulties|
+|---------|---------| -----------|
+| StarGunner | 4       |1|
+
+You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
+are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 
+the general article on Atari environments.
+The versions v0 and v4 are not contained in the "ALE" namespace. I.e. they are instantiated via `gym.make("StarGunner-v0")`.
+
+### Version History
+A thorough discussion of the intricate differences between the versions and configurations can be found in the
+general article on Atari environments. 
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The entire action space is used by default. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release (1.0.0)
+

--- a/docs/pages/environments/atari/tennis.md
+++ b/docs/pages/environments/atari/tennis.md
@@ -1,0 +1,69 @@
+---
+layout: env
+title: Tennis
+grid:
+   - Action Space: Discrete(18)
+   - Observation Shape: (210, 160, 3)
+   - Observation High: 255
+   - Observation Low: 0
+   - Import: <code>gym.make("ALE/Tennis-v5")</code>
+---
+
+### Description
+
+You control the orange player playing against a computer-controlled blue player. The game follows the rules of tennis. 
+The first player to win atleast 6 games with a margin of atleast two games wins the match. If the score is tied at 6-6, the first player to go 2 games up wins the match. Detailed documentation can be found on [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=555)
+
+### Actions
+By default, all actions that can be performed on an Atari 2600 are available in this environment.
+Even if you use v0 or v4 or specify `full_action_space=False` during initialization, all actions will be available in the default flavor.
+
+
+### Observations
+By default, the environment returns the RGB image that is displayed to human players as an observation. However, it is possible to observe
+- The 128 Bytes of RAM of the console
+- A grayscale image
+
+instead. The respective observation spaces are
+- `Box([0 ... 0], [255 ... 255], (128,), uint8)`
+- `Box([[0 ... 0]
+ ...
+ [0  ... 0]], [[255 ... 255]
+ ...
+ [255  ... 255]], (250, 160), uint8)
+`
+
+respectively. The general article on Atari environments outlines different ways to instantiate corresponding environments
+via `gym.make`.
+
+### Rewards
+
+The scoring is as per the sport of tennis, played till one set. For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=555).
+
+### Arguments
+
+```
+env = gym.make("ALE/Tennis-v5")
+```
+
+The various ways to configure the environment are described in detail in the article on Atari environments.
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
+A flavor is a combination of a game mode and a difficulty setting.
+
+| Title   | # Modes |# Difficulties|
+|---------|---------| -----------|
+| Tennis | 2       |4|
+
+You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
+are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 
+the general article on Atari environments.
+The versions v0 and v4 are not contained in the "ALE" namespace. I.e. they are instantiated via `gym.make("Tennis-v0")`.
+
+### Version History
+A thorough discussion of the intricate differences between the versions and configurations can be found in the
+general article on Atari environments. 
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The entire action space is used by default. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release (1.0.0)
+

--- a/docs/pages/environments/atari/time_pilot.md
+++ b/docs/pages/environments/atari/time_pilot.md
@@ -1,0 +1,85 @@
+---
+layout: env
+title: TimePilot
+grid:
+   - Action Space: Discrete(18)
+   - Observation Shape: (210, 160, 3)
+   - Observation High: 255
+   - Observation Low: 0
+   - Import: <code>gym.make("ALE/TimePilot-v5")</code>
+---
+
+### Description
+
+You control an aircraft. Use it to destroy your enemies. As you progress in the game, you encounter enemies with technology that is increasingly from the future. More details can be found on [the Atari Mania page](http://www.atarimania.com/game-atari-2600-vcs-time-pilot_8038.html)
+
+### Actions
+By default, all actions that can be performed on an Atari 2600 are available in this environment.
+However, if you use v0 or v4 or specify `full_action_space=False` during initialization, only a reduced
+number of actions (those that are meaningful in this game) are available. The reduced action space may depend on the flavor of the environment (the combination of `mode` and `difficulty`). The reduced action space for the default 
+flavor looks like this:
+
+| Num | Action                 |
+|-----|------------------------|
+| 0   | NOOP |
+| 1   | FIRE |
+| 2   | UP |
+| 3   | RIGHT |
+| 4   | LEFT |
+| 5   | DOWN |
+| 6   | UPFIRE |
+| 7   | RIGHTFIRE | 
+| 8   | LEFTFIRE | 
+| 9   | DOWNFIRE |
+
+
+### Observations
+By default, the environment returns the RGB image that is displayed to human players as an observation. However, it is possible to observe
+- The 128 Bytes of RAM of the console
+- A grayscale image
+
+instead. The respective observation spaces are
+- `Box([0 ... 0], [255 ... 255], (128,), uint8)`
+- `Box([[0 ... 0]
+ ...
+ [0  ... 0]], [[255 ... 255]
+ ...
+ [255  ... 255]], (250, 160), uint8)
+`
+
+respectively. The general article on Atari environments outlines different ways to instantiate corresponding environments
+via `gym.make`.
+
+
+### Rewards
+
+You score points for destroying enemies, gaining more points for difficult enemies. For a more detailed documentation, see [the Atari Mania page](http://www.atarimania.com/game-atari-2600-vcs-time-pilot_8038.html).
+
+
+### Arguments
+
+```
+env = gym.make("ALE/TimePilot-v5")
+```
+
+The various ways to configure the environment are described in detail in the article on Atari environments.
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`. 
+A flavor is a combination of a game mode and a difficulty setting.
+
+| Title   | # Modes |# Difficulties|
+|---------|---------| -----------|
+| TimePilot | 1       |3|
+
+You may use the suffix "-ram" to switch to the RAM observation space. In v0 and v4, the suffixes "Deterministic" and "NoFrameskip" 
+are available. These are no longer supported in v5. In order to obtain equivalent behavior, pass keyword arguments to `gym.make` as outlined in 
+the general article on Atari environments.
+The versions v0 and v4 are not contained in the "ALE" namespace. I.e. they are instantiated via `gym.make("TimePilot-v0")`.
+
+### Version History
+A thorough discussion of the intricate differences between the versions and configurations can be found in the
+general article on Atari environments. 
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The entire action space is used by default. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release (1.0.0)
+


### PR DESCRIPTION
For `TimePilot` and `StarGunner`, there was no detailed documentation at the AtariAge website, so I added links to [Atari Mania](http://www.atarimania.com/game-atari-2600-vcs-time-pilot_8038.html) page, where they have scans of the original instruction manual. 