### PR TITLE
Use `spaces.Space` docstring

### DIFF
--- a/docs/source/content/spaces.md
+++ b/docs/source/content/spaces.md
@@ -1,6 +1,8 @@
 # Spaces
 
-Spaces define the valid format of observation and action spaces for an environment. 
+```{eval-rst}
+.. autoclass:: gym.spaces.Space
+```
 
 ## General Functions
 

--- a/docs/source/content/spaces.md
+++ b/docs/source/content/spaces.md
@@ -30,7 +30,8 @@ Each space implements the following functions:
 
 ```{eval-rst}
 .. autoclass:: gym.spaces.Box
-
+    
+    .. automethod:: __init__
     .. automethod:: is_bounded
     .. automethod:: sample
 ``` 
@@ -39,6 +40,8 @@ Each space implements the following functions:
 
 ```{eval-rst}
 .. autoclass:: gym.spaces.Discrete
+ 
+    .. autoclass:: __init__
 ``` 
 
 ## MultiBinary
@@ -51,18 +54,24 @@ Each space implements the following functions:
 
 ```{eval-rst}
 .. autoclass:: gym.spaces.MultiDiscrete
+
+    .. automethod:: __init__
 ``` 
 
 ## Dict
 
 ```{eval-rst}
 .. autoclass:: gym.spaces.Dict
+
+    .. automethod:: __init__
 ``` 
 
 ## Tuple
 
 ```{eval-rst}
 .. autoclass:: gym.spaces.Tuple
+
+    .. automethod:: __init__
 ``` 
 
 ## Utility Functions


### PR DESCRIPTION
This PR replaces the markdown description of Spaces by the class docstring of `spaces.Space`.

The corresponding docstring is currently being updated in Gym to give a more detailed description of what spaces do and improve formatting. I think it would be convenient to have the documentation in one place, as opposed to two.

This is just a suggestion, I can also see good reasons not to use the `spaces.Space` docstring for the general description of spaces.

