### PR TITLE
Add docs/ page for gym.openai.com redirect link

### DIFF
--- a/docs/source/docs/index.md
+++ b/docs/source/docs/index.md
@@ -1,0 +1,62 @@
+---
+hide-toc: true
+---
+
+# Gym documentation
+
+## Gym is a standard API for reinforcement learning, and a diverse collection of reference environments.
+
+
+```{figure} https://user-images.githubusercontent.com/15806078/153222406-af5ce6f0-4696-4a24-a683-46ad4939170c.gif
+   :alt: Lunar Lander
+```
+
+**The Gym interface is simple, pythonic, and capable of representing general RL problems:**
+
+```{code-block} python
+
+import gym
+env = gym.make("LunarLander-v2")
+observation, info = env.reset(seed=42, return_info=True)
+for _ in range(1000):
+   env.render()
+   action = policy(observation)  # User-defined policy function
+   observation, reward, done, info = env.step(action)
+
+   if done:
+      observation, info = env.reset(return_info=True)
+env.close()
+``` 
+
+```{toctree}
+:hidden:
+:caption: User Guide
+
+content/api
+content/environment_creation
+content/spaces
+content/vector_api
+content/tutorials
+content/wrappers
+Github <https://github.com/openai/gym>
+```
+
+```{toctree}
+:hidden:
+:caption: Environments
+
+environments/atari/index
+environments/mujoco/index
+environments/toy_text/index
+environments/classic_control/index
+environments/box2d/index
+environments/third_party_environments/index
+```
+
+```{toctree}
+:hidden:
+:caption: Development
+
+Contribute to the Docs <https://github.com/Farama-Foundation/gym-docs>
+
+```


### PR DESCRIPTION
With gym.openai.com being redirected to https://www.gymlibrary.ml/
We noticed that gym.openai.com/docs redirects to a 404 error
This PR fixes that issue by just copying the true `index.md` to `docs/index.md` 