### PR TITLE
Add sphinx reredirects with /docs and /envs redirects to home page

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.githubpages",
     "myst_parser",
+    "sphinx_reredirects"
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -69,3 +70,8 @@ html_static_path = ["_static"]
 html_css_files = [
     "css/custom.css",
 ]
+
+redirects = {
+    "docs/": "",
+    "envs/": ""
+}


### PR DESCRIPTION
Updated PR that uses sphinx reredirect for "envs/" and "docs/" to the root folder 