### PR TITLE
Reverted new render API

### DIFF
--- a/docs/source/content/api.md
+++ b/docs/source/content/api.md
@@ -42,11 +42,11 @@ Not all done signals must be triggered by a "catastrophic failure": Sometimes we
 a fixed number of timesteps, or if the agent has succeeded in completing some task in the environment.
 
 Let's see what the agent-environment loop looks like in Gym.
-This example will run an instance of `LunarLander-v2` environment for 1000 timesteps. Since we pass `render_mode="human"`, you should see a window pop up rendering the environment.
+This example will run an instance of `LunarLander-v2` environment for 1000 timesteps, rendering the environment at each step. You should see a window pop up rendering the environment
 
 ```python
 import gym
-env = gym.make("LunarLander-v2", render_mode="human")
+env = gym.make("LunarLander-v2")
 env.action_space.seed(42)
 
 observation, info = env.reset(seed=42, return_info=True)

--- a/docs/source/content/api.md
+++ b/docs/source/content/api.md
@@ -53,6 +53,7 @@ observation, info = env.reset(seed=42, return_info=True)
 
 for _ in range(1000):
     observation, reward, done, info = env.step(env.action_space.sample())
+    env.render()
 
     if done:
         observation, info = env.reset(return_info=True)

--- a/docs/source/content/environment_creation.md
+++ b/docs/source/content/environment_creation.md
@@ -58,7 +58,7 @@ Let us look at the source code of `GridWorldEnv` piece by piece:
 ### Declaration and Initialization
 Our custom environment will inherit from the abstract class `gym.Env`. You shouldn't forget to add the `metadata` attribute to you class. 
 There, you should specify the render-modes that are supported by your environment (e.g. `"human"`, `"rgb_array"`, `"ansi"`)
-and the framerate at which your environment should be rendered. Every environment should support`None` as render-mode; you don't need to add it in the metadata.
+and the framerate at which your environment should be rendered.
 In `GridWorldEnv`, we will support the modes "rgb_array" and "human" and render at 4 FPS.
 
 The `__init__` method of our environment will accept the integer `size`, that determines the size of the square grid.
@@ -71,17 +71,14 @@ Here is the declaration of `GridWorldEnv` and the implementation of `__init__`:
 ```python
 import gym
 from gym import spaces
+import pygame
 import numpy as np
-from typing import Optional
-from gym.utils.renderer import Renderer
+
 
 class GridWorldEnv(gym.Env):
-    metadata = {"render_modes": ["human", "rgb_array", "single_rgb_array"], "render_fps": 4}
+    metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 4}
 
-    def __init__(self, render_mode: Optional[str] = None, size: int = 5):
-        assert render_mode is None or render_mode in self.metadata["render_modes"]
-        self.render_mode = render_mode  # Define the attribute render_mode in your environment
-
+    def __init__(self, size=5):
         self.size = size  # The size of the square grid
         self.window_size = 512  # The size of the PyGame window
 
@@ -113,20 +110,11 @@ class GridWorldEnv(gym.Env):
         If human-rendering is used, `self.window` will be a reference
         to the window that we draw to. `self.clock` will be a clock that is used
         to ensure that the environment is rendered at the correct framerate in
-        human-mode.
+        human-mode. They will remain `None` until human-mode is used for the
+        first time.
         """
-        if self.render_mode == "human":
-            import pygame  # import here to avoid pygame dependency with no render
-
-            pygame.init()
-            pygame.display.init()
-            self.window = pygame.display.set_mode((self.window_size, self.window_size))
-            self.clock = pygame.time.Clock()
-                
-        # The following line uses the util class Renderer to gather a collection of frames 
-        # using a method that computes a single frame. We will define _render_frame below.
-        self.renderer = Renderer(self.render_mode, self._render_frame)
-            
+        self.window = None
+        self.clock = None
 ```
 
 ### Constructing Observations From Environment States
@@ -173,10 +161,6 @@ and `_get_info` that we implemented earlier for that:
         while np.array_equal(self._target_location, self._agent_location):
             self._target_location = self.np_random.integers(0, self.size, size=2)
 
-        # clean the render collection and add the initial frame
-        self.renderer.reset()
-        self.renderer.render_step()
-
         observation = self._get_obs()
         info = self._get_info()
         return (observation, info) if return_info else observation
@@ -203,9 +187,6 @@ accordingly. Since we are using sparse binary rewards in `GridWorldEnv`, computi
         observation = self._get_obs()
         info = self._get_info()
 
-        # add a frame to the render collection
-        self.renderer.render_step()
-
         return observation, reward, done, info
 ```
 
@@ -214,16 +195,14 @@ Here, we are using PyGame for rendering. A similar approach to rendering is used
 with Gym and you can use it as a skeleton for your own environments:
 
 ```python
-    def render(self):
-        # Just return the list of render frames collected by the Renderer.
-        return self.renderer.get_renders()
+    def render(self, mode="human"):
+        if self.window is None and mode == "human":
+            pygame.init()
+            pygame.display.init()
+            self.window = pygame.display.set_mode((self.window_size, self.window_size))
+        if self.clock is None and mode == "human":
+            self.clock = pygame.time.Clock()
 
-    def _render_frame(self, mode: str):
-        # This will be the function called by the Renderer to collect a single frame.
-        assert mode is not None  # The renderer will not call this function with no-rendering.
-    
-        import pygame # avoid global pygame dependency. This method is not called with no-render.
-    
         canvas = pygame.Surface((self.window_size, self.window_size))
         canvas.fill((255, 255, 255))
         pix_square_size = (
@@ -265,7 +244,6 @@ with Gym and you can use it as a skeleton for your own environments:
             )
 
         if mode == "human":
-            assert self.window is not None
             # The following line copies our drawings from `canvas` to the visible window
             self.window.blit(canvas, canvas.get_rect())
             pygame.event.pump()
@@ -274,7 +252,7 @@ with Gym and you can use it as a skeleton for your own environments:
             # We need to ensure that human-rendering occurs at the predefined framerate.
             # The following line will automatically add a delay to keep the framerate stable.
             self.clock.tick(self.metadata["render_fps"])
-        else:  # rgb_array or single_rgb_array
+        else:  # rgb_array
             return np.transpose(
                 np.array(pygame.surfarray.pixels3d(canvas)), axes=(1, 0, 2)
             )
@@ -282,14 +260,12 @@ with Gym and you can use it as a skeleton for your own environments:
 
 ### Close
 The `close` method should close any open resources that were used by the environment. In many cases,
-you don't actually have to bother to implement this method. However, in our example `render_mode` may
-be `"human"` and we might need to close the window that has been opened:
+you don't actually have to bother to implement this method. However, in our example `render` may have
+been called with `mode="human"` and we might need to close the window that has been opened:
 
 ```python
     def close(self):
         if self.window is not None:
-            import pygame 
-            
             pygame.display.quit()
             pygame.quit()
 ```


### PR DESCRIPTION
This PR reverts 2977d9e, d91549bd6c2b87e2562081cb6f5f4bb151e918b7 and 1fc72bb, which describe the new render API. This lead to a lot of confusion because the new render API is not released yet (see https://github.com/openai/gym/issues/2825, https://github.com/openai/gym/issues/2881 and the questions on discord). I think we should revert these changes for now and reapply them when the new release is out (I guess someone can just `git revert` this commit then). What do you think, @younik , @Pseudo-Rnd-Thoughts ?

Please don't merge until discussed with @younik.